### PR TITLE
workaround for the MSVC / Visual Studio bug of its latest version

### DIFF
--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -1,3 +1,4 @@
+#include "predefined.h"
 #include "logger.h"
 
 #include "internal_error.h"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,4 @@
-
+#include "predefined.h"
 #include "logger.h"
 
 #include "mainwindow.h"

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1,4 +1,4 @@
-
+#include "predefined.h"
 #include "mainwindow.h"
 #include "./ui_mainwindow.h"
 #include <QMessageBox>

--- a/src/predefined.h
+++ b/src/predefined.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#ifdef _MSC_VER 
+//1 > C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.38.33130\include\xutility(1141, 31) : warning C4996 : 'stdext::checked_array_iterator<T *>' : warning STL4043 : stdext::checked_array_iterator, stdext::unchecked_array_iterator, and related factory functions are non - Standard extensions and will be removed in the future.std::span(since C++20) and gsl::span can be used instead.You can define _SILENCE_STDEXT_ARR_ITERS_DEPRECATION_WARNING or _SILENCE_ALL_MS_EXT_DEPRECATION_WARNINGS to suppress this warning.
+#define _SILENCE_STDEXT_ARR_ITERS_DEPRECATION_WARNING
+#endif // _MSC_VER 
+


### PR DESCRIPTION
The latest Visual Studio version brings compiler warning caused by std library extensions.

Here they say it is a bug released about 4 days ago: https://github.com/microsoft/cpprestsdk/issues/1768#issuecomment-1812125631

```
C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.38.33130\include\xutility(1277,12): warning C4996: 'stdext::checked_array_iterator<T *>::_Seek_to': warning STL4043: stdext::checked_array_iterator, stdext::unchecked_array_iterator, and related factory functions are non-Standard extensions and will be removed in the future. std::span (since C++20) and gsl::span can be used instead. You can define _SILENCE_STDEXT_ARR_ITERS_DEPRECATION_WARNING or _SILENCE_ALL_MS_EXT_DEPRECATION_WARNINGS to suppress this warning. [C:\.....\build\src\Tobor.vcxproj]
C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.38.33130\include\xutility(1277,12): warning C4996:         with [C:\....\build\src\Tobor.vcxproj]
C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.38.33130\include\xutility(1277,12): warning C4996:         [ [C:\....\build\src\Tobor.vcxproj]
C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.38.33130\include\xutility(1277,12): warning C4996:             T=char [C:\....\build\src\Tobor.vcxproj]
C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.38.33130\include\xutility(1277,12): warning C4996:         ] [C:\....\build\src\Tobor.vcxproj]
```