### PR TITLE
FIX: CI Mac13 install Qt

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -51,7 +51,7 @@ stages:
        - script: sudo apt-get update && sudo apt-get install qtbase5-dev libqt5svg5-dev
          displayName: "Install Qt (Linux)"
          condition: and(succeeded(), eq( variables['Agent.OS'], 'Linux'))
-       - script: brew install qt@5
+       - script: brew install qt@5 || brew install qt@5
          displayName: "Install Qt (Darwin)"
          condition: and(succeeded(), eq( variables['Agent.OS'], 'Darwin'))
        - script: |
@@ -125,7 +125,7 @@ stages:
        - script: sudo apt-get update && sudo apt-get install build-essential libgl1-mesa-dev qt6-base-dev libqt6svg6 libqt6svg6-dev
          displayName: "Install Qt (Linux)"
          condition: and(succeeded(), eq( variables['Agent.OS'], 'Linux'))
-       - script: brew install qt@6 || brew install qt@6 || brew install qt@6
+       - script: brew install qt@6 || brew install qt@6
          displayName: "Install Qt (Darwin)"
          condition: and(succeeded(), eq( variables['Agent.OS'], 'Darwin'))
        - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -125,7 +125,7 @@ stages:
        - script: sudo apt-get update && sudo apt-get install build-essential libgl1-mesa-dev qt6-base-dev libqt6svg6 libqt6svg6-dev
          displayName: "Install Qt (Linux)"
          condition: and(succeeded(), eq( variables['Agent.OS'], 'Linux'))
-       - script: brew install qt@6
+       - script: brew install qt@6 || brew install qt@6 || brew install qt@6
          displayName: "Install Qt (Darwin)"
          condition: and(succeeded(), eq( variables['Agent.OS'], 'Darwin'))
        - script: |


### PR DESCRIPTION
It looks like brew always installed Qt correctly but just exited with a return code which is not `0`.
So rerunning brew just says:
```
2023-12-16T10:51:15.8800230Z Warning: qt 6.6.1 is already installed and up-to-date.
2023-12-16T10:51:15.8800670Z To reinstall 6.6.1, run:
2023-12-16T10:51:15.8801240Z   brew reinstall qt
2023-12-16T10:51:15.9088610Z 
```
which exits with `0`.